### PR TITLE
chore: use types from @wkc/interfaces

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,8 +40,7 @@
     "dist"
   ],
   "dependencies": {
-    "@types/node-fetch": "^2.5.12",
-    "@well-known-components/interfaces": "^1.4.0",
+    "@well-known-components/interfaces": "^1.4.1",
     "cross-fetch": "^3.1.5"
   }
 }

--- a/src/fetcher.ts
+++ b/src/fetcher.ts
@@ -1,14 +1,10 @@
 import * as crossFetch from 'cross-fetch'
-import * as nodeFetch from 'node-fetch'
-import { IFetchComponent, RequestOptions } from '@well-known-components/interfaces'
+import { IFetchComponent, RequestOptions, Request, Response } from '@well-known-components/interfaces'
 
 const NON_RETRYABLE_STATUS_CODES = [400, 401, 403, 404]
 const IDEMPOTENT_HTTP_METHODS = ['GET', 'HEAD', 'OPTIONS', 'PUT', 'DELETE']
 
-async function fetchWithRetriesAndTimeout(
-  url: nodeFetch.RequestInfo,
-  options: RequestOptions
-): Promise<nodeFetch.Response> {
+async function fetchWithRetriesAndTimeout(url: Request, options: RequestOptions): Promise<Response> {
   const { timeout, abortController, signal: timeoutSignal, retryDelay } = options
   let attempts = options.attempts!
   let timer: NodeJS.Timeout | null = null
@@ -56,7 +52,7 @@ async function fetchWithRetriesAndTimeout(
  * @param defaultHeaders - default headers to be injected on every call performed by this component
  */
 export function createFetchComponent(defaultHeaders?: HeadersInit): IFetchComponent {
-  async function fetch(url: nodeFetch.RequestInfo, options?: RequestOptions): Promise<nodeFetch.Response> {
+  async function fetch(url: Request, options?: RequestOptions): Promise<Response> {
     // Parse options
     const { timeout, method = 'GET', retryDelay = 0, abortController, ...fetchOptions } = options || {}
     let attempts = fetchOptions.attempts || 1

--- a/yarn.lock
+++ b/yarn.lock
@@ -943,10 +943,10 @@
     "@typescript-eslint/types" "5.59.2"
     eslint-visitor-keys "^3.3.0"
 
-"@well-known-components/interfaces@^1.4.0":
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/@well-known-components/interfaces/-/interfaces-1.4.0.tgz#5621e1b687788274f54a6cf781b2a7f4bf6c8d0a"
-  integrity sha512-9MQ7ajKWTs7HWmXaE5sn4sM0HOuRDkVuBrCixTPlAFrrr61Ge5SOZZ5OsOacKoq8RZ80C9bpPjieKcmHQuGWug==
+"@well-known-components/interfaces@^1.4.1":
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/@well-known-components/interfaces/-/interfaces-1.4.1.tgz#310119cd5d9f7f67c7914c49b4d43a105acacec5"
+  integrity sha512-eu4ndE32jF+qKAX/rQ8SFBWh7PCXsOPdArgPweOjK4pdLOyzJaAJaY67/LEerrIp/LNgKDGy0fYbbdZ76BQt1A==
   dependencies:
     "@types/node" "^16.11.19"
     "@types/node-fetch" "^2.5.12"


### PR DESCRIPTION
Updates fetcher to use types from `interfaces` instead of directly import `node-fetch types`.