### PR TITLE
feat: implement default options

### DIFF
--- a/etc/fetch-component.api.md
+++ b/etc/fetch-component.api.md
@@ -5,9 +5,12 @@
 ```ts
 
 import { IFetchComponent } from '@well-known-components/interfaces';
+import { RequestOptions } from '@well-known-components/interfaces';
 
+// Warning: (ae-forgotten-export) The symbol "FetcherOptions" needs to be exported by the entry point index.d.ts
+//
 // @public
-export function createFetchComponent(defaultHeaders?: HeadersInit): IFetchComponent;
+export function createFetchComponent(defaultOptions?: FetcherOptions): IFetchComponent;
 
 // (No @packageDocumentation comment for this package)
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,6 @@
+import { RequestOptions } from '@well-known-components/interfaces'
+
+export type FetcherOptions = {
+  defaultHeaders?: HeadersInit
+  defaultFetcherOptions?: RequestOptions
+}

--- a/test/fetch.spec.ts
+++ b/test/fetch.spec.ts
@@ -129,7 +129,7 @@ describe('fetchComponent', () => {
   it('should make a successful request with defaultHeaders', async () => {
     const customHeader = { 'X-Custom': 'Test' }
 
-    sut = createFetchComponent(customHeader)
+    sut = createFetchComponent({ defaultHeaders: customHeader })
 
     fetchMock.mockResolvedValue(
       new Response('test', {
@@ -141,6 +141,59 @@ describe('fetchComponent', () => {
     await sut.fetch('https://example.com')
 
     expect(fetchMock.mock.calls[0][1].headers).toEqual(customHeader)
+  })
+
+  it('should successfully override a defaultHeaders when the fetcher is called with the same option', async () => {
+    const overwrittenHeader = { 'X-Custom': 'Override' }
+
+    sut = createFetchComponent({ defaultHeaders: { 'X-Custom': 'Test' } })
+
+    fetchMock.mockResolvedValue(
+      new Response('test', {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' }
+      })
+    )
+
+    await sut.fetch('https://example.com', { headers: overwrittenHeader })
+
+    expect(fetchMock.mock.calls[0][1].headers).toEqual(overwrittenHeader)
+  })
+
+  // Setting a default body is not a valid use case, anyways this test is only to validate
+  // that the default options are taking into account
+  it('should make a successful request with defaultFetcherOptions', async () => {
+    const defaultBodyOption = JSON.stringify({ test: 'test' })
+
+    sut = createFetchComponent({ defaultFetcherOptions: { body: defaultBodyOption } })
+
+    fetchMock.mockResolvedValue(
+      new Response('test', {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' }
+      })
+    )
+
+    await sut.fetch('https://example.com')
+
+    expect(fetchMock.mock.calls[0][1].body).toEqual(defaultBodyOption)
+  })
+
+  it('should successfully override a defaultFetcherOptions when the fetcher is called with the same option', async () => {
+    const overwrittenBody = JSON.stringify({ overwritten: 'overwritten' })
+
+    sut = createFetchComponent({ defaultFetcherOptions: { body: JSON.stringify({ test: 'test' }) } })
+
+    fetchMock.mockResolvedValue(
+      new Response('test', {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' }
+      })
+    )
+
+    await sut.fetch('https://example.com', { body: overwrittenBody })
+
+    expect(fetchMock.mock.calls[0][1].body).toEqual(overwrittenBody)
   })
 
   it('should not retry when performing a POST', async () => {


### PR DESCRIPTION
This PRs supports passing default options while creating the `fetcher`. These default options will be overwritten if new values are passed when invoking the fetch function.