### PR TITLE
Update fetcher.ts to work like the browser

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@well-known-components/fetch-component",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "fetch component",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/src/fetcher.ts
+++ b/src/fetcher.ts
@@ -80,12 +80,6 @@ export function createFetchComponent(defaultOptions?: FetcherOptions): IFetchCom
       abortController: controller
     })
 
-    // Throw in case of error
-    if (!response?.ok) {
-      const responseText = await response?.text()
-      throw new Error(`Failed to fetch ${url}. Got status ${response?.status}. Response was '${responseText}'`)
-    }
-
     if (!isUsingNode() && !!response) {
       Object.defineProperty(response, 'buffer', {
         value: async function (): Promise<Buffer> {
@@ -95,8 +89,11 @@ export function createFetchComponent(defaultOptions?: FetcherOptions): IFetchCom
       })
     }
 
-    // Parse response in case of abortion
-    return signal.aborted ? undefined : (response as any)
+    if (signal.aborted) {
+      throw new Error('Request aborted (timed out)')
+    }
+
+    return response
   }
 
   return { fetch }

--- a/test/fetch.spec.ts
+++ b/test/fetch.spec.ts
@@ -58,20 +58,31 @@ describe('fetchComponent', () => {
     expect(response).toEqual(expectedResponseBody)
   })
 
-  it('should throw an error when all retries fail', async () => {
-    fetchMock.mockResolvedValue(
-      new Response('test error', {
-        status: 503,
-        headers: { 'Content-Type': 'text/plain' }
-      })
-    )
+  it('should not throw an error when all retries fail but return latest response', async () => {
+    fetchMock
+      .mockResolvedValueOnce(
+        new Response('test error', {
+          status: 502,
+          headers: { 'Content-Type': 'text/plain' }
+        })
+      )
+      .mockResolvedValue(
+        new Response('test error', {
+          status: 503,
+          headers: { 'Content-Type': 'text/plain' }
+        })
+      )
 
-    await expect(
-      sut.fetch('https://example.com', {
-        attempts: 3,
-        retryDelay: 10
-      } as any)
-    ).rejects.toThrow(`Failed to fetch https://example.com. Got status 503. Response was 'test error'`)
+    const response = await sut.fetch('https://example.com', {
+      attempts: 3,
+      retryDelay: 10
+    } as any)
+
+    expect(response instanceof Response).toBe(true)
+    expect(response.status).toBe(503)
+    expect(response.statusText).toBe('Service Unavailable')
+    const bodyBuffer = await response.buffer()
+    expect(bodyBuffer.toString()).toBe('test error')
 
     expect(fetchMock).toHaveBeenCalledTimes(3)
   })
@@ -97,7 +108,7 @@ describe('fetchComponent', () => {
       sut.fetch('https://example.com', {
         timeout: 500
       } as any)
-    ).rejects.toThrow(`Failed to fetch https://example.com. Got status 408. Response was 'timeout'`)
+    ).rejects.toThrow('Request aborted (timed out)')
 
     clearTimeout(timer)
     expect(fetchMock).toHaveBeenCalledTimes(1)
@@ -214,13 +225,17 @@ describe('fetchComponent', () => {
         })
       )
 
-    await expect(
-      sut.fetch('https://example.com', {
-        method: 'POST',
-        attempts: 3,
-        retryDelay: 10
-      } as any)
-    ).rejects.toThrow(`Failed to fetch https://example.com. Got status 503. Response was 'test error'`)
+    const response = await sut.fetch('https://example.com', {
+      method: 'POST',
+      attempts: 3,
+      retryDelay: 10
+    } as any)
+
+    expect(response instanceof Response).toBe(true)
+    expect(response.status).toBe(503)
+    expect(response.statusText).toBe('Service Unavailable')
+    const bodyBuffer = await response.buffer()
+    expect(bodyBuffer.toString()).toBe('test error')
 
     expect(fetchMock).toHaveBeenCalledTimes(1)
   })
@@ -242,12 +257,16 @@ describe('fetchComponent', () => {
         })
       )
 
-    await expect(
-      sut.fetch('https://example.com', {
-        attempts: 3,
-        retryDelay: 10
-      } as any)
-    ).rejects.toThrow(`Failed to fetch https://example.com. Got status 400. Response was 'test error'`)
+    const response = await sut.fetch('https://example.com', {
+      attempts: 3,
+      retryDelay: 10
+    } as any)
+
+    expect(response instanceof Response).toBe(true)
+    expect(response.status).toBe(400)
+    expect(response.statusText).toBe('Bad Request')
+    const bodyBuffer = await response.buffer()
+    expect(bodyBuffer.toString()).toBe('test error')
 
     expect(fetchMock).toHaveBeenCalledTimes(1)
   })
@@ -269,12 +288,16 @@ describe('fetchComponent', () => {
         })
       )
 
-    await expect(
-      sut.fetch('https://example.com', {
-        attempts: 3,
-        retryDelay: 10
-      } as any)
-    ).rejects.toThrow(`Failed to fetch https://example.com. Got status 401. Response was 'test error'`)
+    const response = await sut.fetch('https://example.com', {
+      attempts: 3,
+      retryDelay: 10
+    } as any)
+
+    expect(response instanceof Response).toBe(true)
+    expect(response.status).toBe(401)
+    expect(response.statusText).toBe('Unauthorized')
+    const bodyBuffer = await response.buffer()
+    expect(bodyBuffer.toString()).toBe('test error')
 
     expect(fetchMock).toHaveBeenCalledTimes(1)
   })
@@ -296,12 +319,16 @@ describe('fetchComponent', () => {
         })
       )
 
-    await expect(
-      sut.fetch('https://example.com', {
-        attempts: 3,
-        retryDelay: 10
-      } as any)
-    ).rejects.toThrow(`Failed to fetch https://example.com. Got status 403. Response was 'test error'`)
+    const response = await sut.fetch('https://example.com', {
+      attempts: 3,
+      retryDelay: 10
+    } as any)
+
+    expect(response instanceof Response).toBe(true)
+    expect(response.status).toBe(403)
+    expect(response.statusText).toBe('Forbidden')
+    const bodyBuffer = await response.buffer()
+    expect(bodyBuffer.toString()).toBe('test error')
 
     expect(fetchMock).toHaveBeenCalledTimes(1)
   })
@@ -323,12 +350,16 @@ describe('fetchComponent', () => {
         })
       )
 
-    await expect(
-      sut.fetch('https://example.com', {
-        attempts: 3,
-        retryDelay: 10
-      } as any)
-    ).rejects.toThrow(`Failed to fetch https://example.com. Got status 404. Response was 'test error'`)
+    const response = await sut.fetch('https://example.com', {
+      attempts: 3,
+      retryDelay: 10
+    } as any)
+
+    expect(response instanceof Response).toBe(true)
+    expect(response.status).toBe(404)
+    expect(response.statusText).toBe('Not Found')
+    const bodyBuffer = await response.buffer()
+    expect(bodyBuffer.toString()).toBe('test error')
 
     expect(fetchMock).toHaveBeenCalledTimes(1)
   })

--- a/test/how-to-examples.spec.ts
+++ b/test/how-to-examples.spec.ts
@@ -15,8 +15,7 @@ describe('How to', () => {
     controller.abort()
 
     // Fetch is not done, undefined response is returned
-    const response = await fetchPromise
-    expect(response).toBeUndefined()
+    await expect(fetchPromise).rejects.toThrow('Request aborted (timed out)')
   })
 
   it('buffer a response', async () => {


### PR DESCRIPTION
This PR  removes a forceful throw and `return undefined` to copy the default behavior of the browser.

---

### Context

I'm trying to use 
```ts
if(request.status == 400) { 
  ...
}
```
but the 
```
if !request.ok then throw
```
was preventing me from doing it

